### PR TITLE
feat: support Etherpad hosted at subpath

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,16 +16,26 @@ exports.connect = (host) => {
   // If host is undefined set to local host
   if (!host) {
     padState.host = 'http://127.0.0.1:9001';
+    padState.path = '';
     padState.padId = randomString();
   } else {
     const parsed = new URL(host);
     padState.host = `${parsed.protocol}//${parsed.host}`;
-    padState.padId = parsed.pathname.replace('/p/', '');
+    const padIdParam = '/p/';
+    const indexOfPadId = parsed.pathname.indexOf(padIdParam);
+    if (indexOfPadId >= 0) {
+      padState.path = parsed.pathname.substring(0, indexOfPadId)
+      padState.padId = parsed.pathname.substring(indexOfPadId + padIdParam.length)
+    } else {
+      padState.path = '';
+      padState.padId = randomString();
+    }
   }
 
   // Connect to Socket
-  superagent.get(`${padState.host}/p/${padState.padId}`).then((d) => {
+  superagent.get(`${padState.host}${padState.path}/p/${padState.padId}`).then((d) => {
     const socket = require('socket.io-client')(padState.host, {
+      'path': `${padState.path}/socket.io`,
       'query': `padId=${padState.padId}`,
       'forceNew': true,
       'timeout': 1000,


### PR DESCRIPTION
The current logic does not work when Etherpad is hosted at a subpath (e.g. `https://example.org/tools/etherpad`). This PR adapts the logic to work for such cases too.