### PR TITLE
ci: publish version from package.json (drop dirty-tree auto-bump)

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -69,19 +69,20 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org/
       -
-        name: Bump version (patch)
+        name: Tag the version in package.json (if not already tagged)
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0) || exit 1
-          NEW_COMMITS=$(git rev-list --count "${LATEST_TAG}"..) || exit 1
-          [ "${NEW_COMMITS}" -gt 0 ] || exit 0
+          PKG_VER=$(node -p "require('./package.json').version")
+          if git rev-parse -q --verify "refs/tags/v${PKG_VER}" >/dev/null; then
+            echo "v${PKG_VER} already tagged; nothing to do."
+            exit 0
+          fi
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          pnpm i
-          pnpm version patch
-          git push --follow-tags
+          git tag "v${PKG_VER}"
+          git push origin "v${PKG_VER}"
       -
-        run: pnpm i
+        run: pnpm i --frozen-lockfile
       -
-        run: pnpm publish
+        run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Summary

Replace the broken \`pnpm version patch\` auto-bump in \`npmpublish.yml\` with a simpler tag-and-publish-from-package.json flow.

## Why

The previous Bump-version step ran \`pnpm i\` and then \`pnpm version patch\`. Under pnpm 11, \`pnpm i\` dirties \`pnpm-workspace.yaml\` on every invocation (the build-script approval wizard re-emits its prompt), so \`pnpm version\` then aborts with:

\`\`\`
[ERR_PNPM_UNCLEAN_WORKING_TREE] Working tree is not clean. Commit or stash your changes.
\`\`\`

That's how 4.0.3 failed to publish after #131 merged — the test job ran fine, publish-npm bailed on the dirty tree, npm still has 4.0.2.

## New flow

1. Read the version from \`package.json\` directly. If a matching \`vX.Y.Z\` tag already exists, exit cleanly (no-op).
2. Otherwise tag the merge commit and push the tag.
3. \`pnpm i --frozen-lockfile\` then \`pnpm publish --no-git-checks\` (the latter so transient pnpm working-tree state can't block).

Practical effect: contributors bump the version in the PR that needs to ship (we already did this for 4.0.3 in #131), and merging publishes it.

## Test plan

- [x] Workflow YAML parses (validated locally)
- [ ] After merge: \`v4.0.3\` tag created on main, \`etherpad-cli-client@4.0.3\` lands on npm

Refs the dead 25965886065 publish run.