### PR TITLE
Add license metadata to package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "etherpad-cli-client",
   "description": "Node Client for Etherpad",
+  
   "version": "4.0.3",
+    "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@11.1.2",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "etherpad-cli-client",
   "description": "Node Client for Etherpad",
   
-  "version": "4.0.3",
+"version": "4.0.3",
     "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@11.1.2",


### PR DESCRIPTION
Summary
Adds Apache-2.0 license metadata to package.json, matching the repository LICENSE file and making the published npm metadata clearer.

Verification
Checked npm metadata for etherpad-cli-client 4.0.3 has no license field.
Confirmed repository LICENSE is Apache License 2.0.
Parsed the edited package.json and verified license is Apache-2.0.

Tests not run; metadata-only change.