### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "etherpad-cli-client",
   "description": "Node Client for Etherpad",
   "version": "4.0.3",
+  "bugs": {
+    "url": "https://github.com/ether/etherpad-cli-client/issues"
+  },
   "type": "module",
   "packageManager": "pnpm@11.1.2",
   "author": {


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.